### PR TITLE
chore: enforce LF line endings via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,25 @@
+# ========================================================================
+# Line Endings Policy
+# - Enforce LF for all text files, regardless of Operating System/Editor.
+# - Explicitly mark binaries to prevent corruption.
+# ========================================================================
+
+# Auto-detect text and normalize line endings in the repository
+* text=auto eol=lf
+
+# ---- Explicit binaries (these are never normalized) ----
+*.png  binary
+*.jpg  binary
+*.jpeg binary
+*.gif  binary
+*.webp binary
+*.ico  binary
+*.svg  -text
+*.pdf  binary
+
+# ---- Common generated / vendor-like files ----
+*.lock text eol=lf
+
+# ---- Shell scripts must be LF (Docker/Linux) ----
+*.sh   text eol=lf
+*.bash text eol=lf


### PR DESCRIPTION
## Summary of Changes
This pull request standardizes repository line endings by introducing a root-level `.gitattributes` file that enforces LF line endings for all text files.

Although the repository was already normalized to LF, there was no repository-level policy enforcing this behavior. This meant that future commits from different operating systems or editor configurations could accidentally introduce CRLF line endings.

This PR establishes a permanent source of truth for line ending behavior.

**What this change introduces:**

- Adds a root `.gitattributes` file
- Enforces `LF` (`eol=lf`) for all text files
- Explicitly protects binary assets (images, etc.) from normalization
- Prevents future CRLF commits across Windows, macOS, and Linux environments

**Result:**

- Consistent line endings across the entire repository
- Prevention of whitespace-only diffs caused by line ending changes
- Improved compatibility with Linux-based environments such as Docker
- More stable linting and formatting behavior

A renormalization check (`git add --renormalize .`) was executed and confirmed that the repository was already fully normalized, so no file content changes were required.

## Related Issue

Fixes #4 

## How Has This Been Tested?

### Repository Validation

The repository was checked to ensure no CRLF characters remain in tracked files.

```bash
git add --renormalize .
git diff --check
git grep -I $'\r'
git ls-files --eol