### PR TITLE
fix(portfolio): enforce validation for quantity, prices, and trade da…

### DIFF
--- a/frontend/src/features/portfolio/components/PositionDialogs.styles.ts
+++ b/frontend/src/features/portfolio/components/PositionDialogs.styles.ts
@@ -1,0 +1,12 @@
+import Button from '@mui/material/Button';
+import { styled } from '@mui/material/styles';
+
+export const DialogFieldLabelWrap = styled('span')(({ theme }) => ({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: theme.spacing(0.25),
+}));
+
+export const DialogSubmitButton = styled(Button)(() => ({
+  minWidth: 140,
+}));

--- a/frontend/src/features/portfolio/components/PositionDialogs.test.tsx
+++ b/frontend/src/features/portfolio/components/PositionDialogs.test.tsx
@@ -1,0 +1,176 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import dayjs from 'dayjs';
+
+import theme from '@shared/theme';
+import { PositionDialogs } from './PositionDialogs';
+
+function baseProps() {
+  return {
+    tab: 'open' as const,
+    selected: null,
+
+    addOpen: true,
+    closeOpen: false,
+    editOpen: false,
+    deleteOpen: false,
+
+    onCloseAdd: jest.fn(),
+    onCloseClose: jest.fn(),
+    onCloseEdit: jest.fn(),
+    onCloseDelete: jest.fn(),
+
+    newTicker: '',
+    newQuantity: '',
+    newBuyPrice: '',
+    newBuyDate: dayjs(),
+    newSellPrice: '',
+    newSellDate: dayjs(),
+    tickerError: '',
+    quantityError: '',
+    buyPriceError: '',
+    buyDateError: '',
+    sellPriceError: '',
+    sellDateError: '',
+
+    setNewTicker: jest.fn(),
+    setNewQuantity: jest.fn(),
+    setNewBuyPrice: jest.fn(),
+    setNewBuyDate: jest.fn(),
+    setNewSellPrice: jest.fn(),
+    setNewSellDate: jest.fn(),
+
+    onAddSubmit: jest.fn(),
+    onCloseSubmit: jest.fn(),
+    onEditSubmit: jest.fn(),
+    onDeleteConfirm: jest.fn(),
+
+    isAdding: false,
+    isClosing: false,
+    isEditing: false,
+    isDeleting: false,
+  };
+}
+
+function renderDialog(overrides: Partial<ReturnType<typeof baseProps>> = {}) {
+  return render(
+    <ThemeProvider theme={theme}>
+      <PositionDialogs {...baseProps()} {...overrides} />
+    </ThemeProvider>,
+  );
+}
+
+describe('PositionDialogs', () => {
+  it('renders inline validation messages for ticker, quantity, buy price, and buy date', () => {
+    renderDialog({
+      tickerError: 'Ticker is required',
+      quantityError: 'Quantity must be greater than 0',
+      buyPriceError: 'Buy price is required',
+      buyDateError: 'Buy date is required',
+    });
+
+    expect(screen.getByText('Ticker is required')).toBeInTheDocument();
+    expect(screen.getByText('Quantity must be greater than 0')).toBeInTheDocument();
+    expect(screen.getByText('Buy price is required')).toBeInTheDocument();
+    expect(screen.getByText('Buy date is required')).toBeInTheDocument();
+  });
+
+  it('shows tooltip content for ticker, quantity, and buy price', async () => {
+    renderDialog();
+
+    const tickerInfoButton = screen.getByRole('button', { name: /ticker info/i });
+    fireEvent.mouseOver(tickerInfoButton);
+    expect(
+      await screen.findByText(/enter the market ticker symbol for this holding/i),
+    ).toBeInTheDocument();
+    fireEvent.mouseLeave(tickerInfoButton);
+
+    const quantityInfoButton = screen.getByRole('button', { name: /quantity info/i });
+    fireEvent.mouseOver(quantityInfoButton);
+    expect(
+      await screen.findByText(
+        /fractional shares are supported, but the quantity must be greater than 0/i,
+      ),
+    ).toBeInTheDocument();
+    fireEvent.mouseLeave(quantityInfoButton);
+
+    const buyPriceInfoButton = screen.getByRole('button', { name: /buy price info/i });
+    fireEvent.mouseOver(buyPriceInfoButton);
+    expect(
+      await screen.findByText(/this value is required and must be greater than 0/i),
+    ).toBeInTheDocument();
+  });
+
+  it('renders inline validation messages for sell price and sell date in the close dialog', () => {
+    render(
+      <ThemeProvider theme={theme}>
+        <PositionDialogs
+          {...baseProps()}
+          addOpen={false}
+          closeOpen
+          selected={{
+            id: 1,
+            ticker: 'AAPL',
+            quantity: 1,
+            buyPrice: 10,
+            buyDate: new Date().toISOString(),
+          }}
+          sellPriceError="Sell price is required"
+          sellDateError="Sell date is required"
+        />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByText('Sell price is required')).toBeInTheDocument();
+    expect(screen.getByText('Sell date is required')).toBeInTheDocument();
+  });
+
+  it('shows tooltip content for sell price and date', async () => {
+    render(
+      <ThemeProvider theme={theme}>
+        <PositionDialogs
+          {...baseProps()}
+          addOpen={false}
+          closeOpen
+          selected={{
+            id: 1,
+            ticker: 'AAPL',
+            quantity: 1,
+            buyPrice: 10,
+            buyDate: new Date().toISOString(),
+          }}
+        />
+      </ThemeProvider>,
+    );
+
+    const sellPriceInfoButton = screen.getByRole('button', { name: /sell price info/i });
+    fireEvent.mouseOver(sellPriceInfoButton);
+    expect(
+      await screen.findByText(/zero is allowed if the position became worthless/i),
+    ).toBeInTheDocument();
+    fireEvent.mouseLeave(sellPriceInfoButton);
+
+    const sellDateInfoButton = screen.getByRole('button', { name: /sell date info/i });
+    fireEvent.mouseOver(sellDateInfoButton);
+    expect(
+      await screen.findByText(/invalid or empty dates are not accepted/i),
+    ).toBeInTheDocument();
+  });
+
+  it('renders inline validation message for buy date in edit mode', () => {
+    renderDialog({
+      addOpen: false,
+      editOpen: true,
+      selected: {
+        id: 1,
+        ticker: 'AAPL',
+        quantity: 1,
+        buyPrice: 10,
+        buyDate: new Date().toISOString(),
+      },
+      buyDateError: 'Enter a valid buy date',
+    });
+
+    expect(screen.getByText('Enter a valid buy date')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/portfolio/components/PositionDialogs.tsx
+++ b/frontend/src/features/portfolio/components/PositionDialogs.tsx
@@ -1,3 +1,4 @@
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 import Dialog from '@mui/material/Dialog';
@@ -10,7 +11,10 @@ import { DatePicker, LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import type { Dayjs } from 'dayjs';
 
+import { AppTooltip, KpiInfoButton } from '@shared/ui';
+
 import type { Position } from '../types/position';
+import { DialogFieldLabelWrap, DialogSubmitButton } from './PositionDialogs.styles';
 
 type Props = {
   tab: 'open' | 'closed';
@@ -36,6 +40,11 @@ type Props = {
   newSellPrice: string;
   newSellDate: Dayjs | null;
   tickerError: string;
+  quantityError: string;
+  buyPriceError: string;
+  buyDateError: string;
+  sellPriceError: string;
+  sellDateError: string;
 
   // Setters
   setNewTicker: (v: string) => void;
@@ -57,6 +66,55 @@ type Props = {
   isEditing: boolean;
   isDeleting: boolean;
 };
+
+const POSITIVE_NUMBER_INPUT_PROPS = {
+  min: 0.00000001,
+  step: 'any',
+};
+
+const ANY_NUMBER_INPUT_PROPS = {
+  step: 'any',
+};
+
+type FieldLabelWithTipProps = {
+  label: string;
+  tip: React.ReactNode;
+};
+
+function FieldLabelWithTip({ label, tip }: FieldLabelWithTipProps) {
+  return (
+    <DialogFieldLabelWrap>
+      <span>{label}</span>
+      <AppTooltip title={tip}>
+        <span>
+          <KpiInfoButton 
+		    aria-label={`${label} info`}
+			tabIndex={-1}
+			disableRipple
+			disableFocusRipple
+		  >
+            <InfoOutlinedIcon fontSize="inherit" />
+          </KpiInfoButton>
+        </span>
+      </AppTooltip>
+    </DialogFieldLabelWrap>
+  );
+}
+
+const TICKER_TIP =
+  'Enter the market ticker symbol for this holding, for example AMZN, MSFT, or AAPL.';
+
+const QUANTITY_TIP =
+  'Enter the number of shares purchased. Fractional shares are supported, but the quantity must be greater than 0';
+
+const BUY_PRICE_TIP =
+  'Enter the purchase price per share. This value is required and must be greater than 0.';
+
+const SELL_PRICE_TIP =
+  'Enter the selling price per share used to close the position. This value is required. Zero is allowed if the position became worthless.';
+
+const DATE_TIP =
+  'Enter a valid calendar date or select one using the calendar picker. Invalid or empty dates are not accepted.';
 
 export function PositionDialogs(props: Props) {
   const {
@@ -80,6 +138,11 @@ export function PositionDialogs(props: Props) {
     newSellPrice,
     newSellDate,
     tickerError,
+    quantityError,
+    buyPriceError,
+    buyDateError,
+    sellPriceError,
+    sellDateError,
 
     setNewTicker,
     setNewQuantity,
@@ -107,7 +170,7 @@ export function PositionDialogs(props: Props) {
           <TextField
             fullWidth
             margin="dense"
-            label="Ticker"
+            label={<FieldLabelWithTip label="Ticker" tip={TICKER_TIP} />}
             value={newTicker}
             error={Boolean(tickerError)}
             helperText={tickerError}
@@ -116,42 +179,54 @@ export function PositionDialogs(props: Props) {
           <TextField
             fullWidth
             margin="dense"
-            label="Quantity"
+            label={<FieldLabelWithTip label="Quantity" tip={QUANTITY_TIP} />}
             type="number"
             value={newQuantity}
+            error={Boolean(quantityError)}
+            helperText={quantityError}
+            inputProps={POSITIVE_NUMBER_INPUT_PROPS}
             onChange={(e) => setNewQuantity(e.target.value)}
           />
           <TextField
             fullWidth
             margin="dense"
-            label="Buy Price"
+            label={<FieldLabelWithTip label="Buy Price" tip={BUY_PRICE_TIP} />}
             type="number"
             value={newBuyPrice}
+            error={Boolean(buyPriceError)}
+            helperText={buyPriceError}
+            inputProps={POSITIVE_NUMBER_INPUT_PROPS}
             onChange={(e) => setNewBuyPrice(e.target.value)}
           />
 
           <LocalizationProvider dateAdapter={AdapterDayjs}>
             <DatePicker
-              label="Buy Date"
+              label={<FieldLabelWithTip label="Buy Date" tip={DATE_TIP} />}
               value={newBuyDate}
               onChange={(d) => setNewBuyDate(d)}
               disableFuture
-              slotProps={{ textField: { fullWidth: true, margin: 'dense' } }}
+              slotProps={{
+                textField: {
+                  fullWidth: true,
+                  margin: 'dense',
+                  error: Boolean(buyDateError),
+                  helperText: buyDateError,
+                },
+              }}
             />
           </LocalizationProvider>
         </DialogContent>
 
         <DialogActions>
           <Button onClick={onCloseAdd}>Cancel</Button>
-          <Button
+          <DialogSubmitButton
             onClick={onAddSubmit}
             disabled={isAdding}
             variant="contained"
             startIcon={isAdding ? <CircularProgress size={18} /> : undefined}
-            sx={{ minWidth: 140 }}
           >
             {isAdding ? 'Saving…' : 'Save'}
-          </Button>
+          </DialogSubmitButton>
         </DialogActions>
       </Dialog>
 
@@ -161,34 +236,43 @@ export function PositionDialogs(props: Props) {
           <TextField
             fullWidth
             margin="dense"
-            label="Sell Price"
+            label={<FieldLabelWithTip label="Sell Price" tip={SELL_PRICE_TIP} />}
             type="number"
             value={newSellPrice}
+            error={Boolean(sellPriceError)}
+            helperText={sellPriceError}
+            inputProps={ANY_NUMBER_INPUT_PROPS}
             onChange={(e) => setNewSellPrice(e.target.value)}
           />
 
           <LocalizationProvider dateAdapter={AdapterDayjs}>
             <DatePicker
-              label="Sell Date"
+              label={<FieldLabelWithTip label="Sell Date" tip={DATE_TIP} />}
               value={newSellDate}
               onChange={(d) => setNewSellDate(d)}
               disableFuture
-              slotProps={{ textField: { fullWidth: true, margin: 'dense' } }}
+              slotProps={{
+                textField: {
+                  fullWidth: true,
+                  margin: 'dense',
+                  error: Boolean(sellDateError),
+                  helperText: sellDateError,
+                },
+              }}
             />
           </LocalizationProvider>
         </DialogContent>
 
         <DialogActions>
           <Button onClick={onCloseClose}>Cancel</Button>
-          <Button
+          <DialogSubmitButton
             onClick={onCloseSubmit}
             disabled={isClosing}
             variant="contained"
             startIcon={isClosing ? <CircularProgress size={18} /> : undefined}
-            sx={{ minWidth: 140 }}
           >
             {isClosing ? 'Closing…' : 'Close'}
-          </Button>
+          </DialogSubmitButton>
         </DialogActions>
       </Dialog>
 
@@ -198,27 +282,40 @@ export function PositionDialogs(props: Props) {
           <TextField
             fullWidth
             margin="dense"
-            label="Quantity"
+            label={<FieldLabelWithTip label="Quantity" tip={QUANTITY_TIP} />}
             type="number"
             value={newQuantity}
+            error={Boolean(quantityError)}
+            helperText={quantityError}
+            inputProps={POSITIVE_NUMBER_INPUT_PROPS}
             onChange={(e) => setNewQuantity(e.target.value)}
           />
           <TextField
             fullWidth
             margin="dense"
-            label="Buy Price"
+            label={<FieldLabelWithTip label="Buy Price" tip={BUY_PRICE_TIP} />}
             type="number"
             value={newBuyPrice}
+            error={Boolean(buyPriceError)}
+            helperText={buyPriceError}
+            inputProps={POSITIVE_NUMBER_INPUT_PROPS}
             onChange={(e) => setNewBuyPrice(e.target.value)}
           />
 
           <LocalizationProvider dateAdapter={AdapterDayjs}>
             <DatePicker
-              label="Buy Date"
+              label={<FieldLabelWithTip label="Buy Date" tip={DATE_TIP} />}
               value={newBuyDate}
               onChange={(d) => setNewBuyDate(d)}
               disableFuture
-              slotProps={{ textField: { fullWidth: true, margin: 'dense' } }}
+              slotProps={{
+                textField: {
+                  fullWidth: true,
+                  margin: 'dense',
+                  error: Boolean(buyDateError),
+                  helperText: buyDateError,
+                },
+              }}
             />
           </LocalizationProvider>
 
@@ -227,18 +324,28 @@ export function PositionDialogs(props: Props) {
               <TextField
                 fullWidth
                 margin="dense"
-                label="Sell Price"
+                label={<FieldLabelWithTip label="Sell Price" tip={SELL_PRICE_TIP} />}
                 type="number"
                 value={newSellPrice}
+                error={Boolean(sellPriceError)}
+                helperText={sellPriceError}
+                inputProps={ANY_NUMBER_INPUT_PROPS}
                 onChange={(e) => setNewSellPrice(e.target.value)}
               />
               <LocalizationProvider dateAdapter={AdapterDayjs}>
                 <DatePicker
-                  label="Sell Date"
+                  label={<FieldLabelWithTip label="Sell Date" tip={DATE_TIP} />}
                   value={newSellDate}
                   onChange={(d) => setNewSellDate(d)}
                   disableFuture
-                  slotProps={{ textField: { fullWidth: true, margin: 'dense' } }}
+                  slotProps={{
+                    textField: {
+                      fullWidth: true,
+                      margin: 'dense',
+                      error: Boolean(sellDateError),
+                      helperText: sellDateError,
+                    },
+                  }}
                 />
               </LocalizationProvider>
             </>
@@ -247,15 +354,14 @@ export function PositionDialogs(props: Props) {
 
         <DialogActions>
           <Button onClick={onCloseEdit}>Cancel</Button>
-          <Button
+          <DialogSubmitButton
             onClick={onEditSubmit}
             disabled={isEditing}
             variant="contained"
             startIcon={isEditing ? <CircularProgress size={18} /> : undefined}
-            sx={{ minWidth: 140 }}
           >
             {isEditing ? 'Saving…' : 'Save'}
-          </Button>
+          </DialogSubmitButton>
         </DialogActions>
       </Dialog>
 
@@ -267,16 +373,15 @@ export function PositionDialogs(props: Props) {
 
         <DialogActions>
           <Button onClick={onCloseDelete}>Cancel</Button>
-          <Button
+          <DialogSubmitButton
             color="error"
             onClick={onDeleteConfirm}
             disabled={isDeleting}
             variant="contained"
             startIcon={isDeleting ? <CircularProgress size={18} /> : undefined}
-            sx={{ minWidth: 140 }}
           >
             {isDeleting ? 'Deleting…' : 'Delete'}
-          </Button>
+          </DialogSubmitButton>
         </DialogActions>
       </Dialog>
     </>

--- a/frontend/src/features/portfolio/hooks/usePositionsPage.test.tsx
+++ b/frontend/src/features/portfolio/hooks/usePositionsPage.test.tsx
@@ -1,0 +1,454 @@
+import React from 'react';
+import dayjs from 'dayjs';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import API from '@shared/lib/axios';
+import { usePositionsPage } from './usePositionsPage';
+
+jest.mock('@shared/lib/axios', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn(),
+  },
+}));
+
+jest.mock('@features/portfolio/hooks/usePositionWS', () => ({
+  __esModule: true,
+  usePositionWS: jest.fn(),
+}));
+
+jest.mock('@features/market-data/hooks/useQuotes', () => ({
+  __esModule: true,
+  useQuotes: jest.fn(() => ({
+    data: [],
+    isLoading: false,
+  })),
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+const mockedApi = API as jest.Mocked<typeof API>;
+
+describe('usePositionsPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedApi.get.mockResolvedValue({ data: [] } as never);
+    mockedApi.post.mockResolvedValue({
+      data: {
+        id: 1,
+        ticker: 'AAPL',
+        quantity: 1,
+        buyPrice: 10,
+        buyDate: new Date().toISOString(),
+      },
+    } as never);
+    mockedApi.put.mockResolvedValue({ data: {} } as never);
+    mockedApi.delete.mockResolvedValue({} as never);
+  });
+
+  it('requires a ticker before adding a position', async () => {
+    const { result } = renderHook(() => usePositionsPage(false), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(mockedApi.get).toHaveBeenCalled());
+
+    act(() => {
+      result.current.openAddDialog();
+    });
+
+    act(() => {
+      result.current.onAddSubmit();
+    });
+
+    await waitFor(() => {
+      expect(result.current.tickerError).toBe('Ticker is required');
+    });
+    expect(mockedApi.post).not.toHaveBeenCalled();
+  });
+
+  it('requires quantity before adding a position', async () => {
+    const { result } = renderHook(() => usePositionsPage(false), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(mockedApi.get).toHaveBeenCalled());
+
+    act(() => {
+      result.current.openAddDialog();
+    });
+
+    act(() => {
+      result.current.setNewTicker('AAPL');
+    });
+
+    act(() => {
+      result.current.onAddSubmit();
+    });
+
+    await waitFor(() => {
+      expect(result.current.quantityError).toBe('Quantity must be greater than 0');
+    });
+    expect(mockedApi.post).not.toHaveBeenCalled();
+  });
+
+  it('requires buy price before adding a position', async () => {
+    const { result } = renderHook(() => usePositionsPage(false), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(mockedApi.get).toHaveBeenCalled());
+
+    act(() => {
+      result.current.openAddDialog();
+    });
+
+    act(() => {
+      result.current.setNewTicker('AAPL');
+      result.current.setNewQuantity('1');
+    });
+
+    act(() => {
+      result.current.onAddSubmit();
+    });
+
+    await waitFor(() => {
+      expect(result.current.buyPriceError).toBe('Buy price is required');
+    });
+    expect(mockedApi.post).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-positive buy price when adding a position', async () => {
+    const { result } = renderHook(() => usePositionsPage(false), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(mockedApi.get).toHaveBeenCalled());
+
+    act(() => {
+      result.current.openAddDialog();
+    });
+
+    act(() => {
+      result.current.setNewTicker('AAPL');
+      result.current.setNewQuantity('1');
+      result.current.setNewBuyPrice('0');
+    });
+
+    act(() => {
+      result.current.onAddSubmit();
+    });
+
+    await waitFor(() => {
+      expect(result.current.buyPriceError).toBe('Buy price must be greater than 0');
+    });
+    expect(mockedApi.post).not.toHaveBeenCalled();
+  });
+
+  it('requires buy date before adding a position and sets inline error', async () => {
+    const { result } = renderHook(() => usePositionsPage(false), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(mockedApi.get).toHaveBeenCalled());
+
+    act(() => {
+      result.current.openAddDialog();
+    });
+
+    act(() => {
+      result.current.setNewTicker('AAPL');
+      result.current.setNewQuantity('1');
+      result.current.setNewBuyPrice('10');
+      result.current.setNewBuyDate(null);
+    });
+
+    act(() => {
+      result.current.onAddSubmit();
+    });
+
+    await waitFor(() => {
+      expect(result.current.buyDateError).toBe('Buy date is required');
+    });
+    expect(mockedApi.post).not.toHaveBeenCalled();
+  });
+
+  it('requires a valid buy date before adding a position and sets inline error', async () => {
+    const { result } = renderHook(() => usePositionsPage(false), { wrapper: createWrapper() });
+    const invalidDate = dayjs('not-a-real-date');
+
+    await waitFor(() => expect(mockedApi.get).toHaveBeenCalled());
+
+    act(() => {
+      result.current.openAddDialog();
+    });
+
+    act(() => {
+      result.current.setNewTicker('AAPL');
+      result.current.setNewQuantity('1');
+      result.current.setNewBuyPrice('10');
+      result.current.setNewBuyDate(invalidDate);
+    });
+
+    act(() => {
+      result.current.onAddSubmit();
+    });
+
+    await waitFor(() => {
+      expect(result.current.buyDateError).toBe('Enter a valid buy date');
+    });
+    expect(mockedApi.post).not.toHaveBeenCalled();
+  });
+
+  it('allows fractional quantity when the value is greater than 0', async () => {
+    const { result } = renderHook(() => usePositionsPage(false), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(mockedApi.get).toHaveBeenCalled());
+
+    act(() => {
+      result.current.openAddDialog();
+    });
+
+    act(() => {
+      result.current.setNewTicker('aapl');
+      result.current.setNewQuantity('0.1');
+      result.current.setNewBuyPrice('10');
+    });
+
+    act(() => {
+      result.current.onAddSubmit();
+    });
+
+    await waitFor(() => {
+      expect(mockedApi.post).toHaveBeenCalledWith(
+        '/positions',
+        expect.objectContaining({
+          ticker: 'AAPL',
+          quantity: 0.1,
+          buyPrice: 10,
+        }),
+      );
+    });
+  });
+
+  it('requires buy price when editing a position', async () => {
+    const { result } = renderHook(() => usePositionsPage(false), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(mockedApi.get).toHaveBeenCalled());
+
+    act(() => {
+      result.current.openEditDialog({
+        id: 7,
+        ticker: 'AAPL',
+        quantity: 1,
+        buyPrice: 12,
+        buyDate: new Date().toISOString(),
+      });
+    });
+
+    act(() => {
+      result.current.setNewBuyPrice('');
+    });
+
+    act(() => {
+      result.current.onEditSubmit();
+    });
+
+    await waitFor(() => {
+      expect(result.current.buyPriceError).toBe('Buy price is required');
+    });
+    expect(mockedApi.put).not.toHaveBeenCalled();
+  });
+
+  it('requires buy date when editing a position and sets inline error', async () => {
+    const { result } = renderHook(() => usePositionsPage(false), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(mockedApi.get).toHaveBeenCalled());
+
+    act(() => {
+      result.current.openEditDialog({
+        id: 7,
+        ticker: 'AAPL',
+        quantity: 1,
+        buyPrice: 12,
+        buyDate: new Date().toISOString(),
+      });
+    });
+
+    act(() => {
+      result.current.setNewBuyDate(null);
+    });
+
+    act(() => {
+      result.current.onEditSubmit();
+    });
+
+    await waitFor(() => {
+      expect(result.current.buyDateError).toBe('Buy date is required');
+    });
+    expect(mockedApi.put).not.toHaveBeenCalled();
+  });
+
+  it('requires a valid buy date when editing a position and sets inline error', async () => {
+    const { result } = renderHook(() => usePositionsPage(false), { wrapper: createWrapper() });
+    const invalidDate = dayjs('not-a-real-date');
+
+    await waitFor(() => expect(mockedApi.get).toHaveBeenCalled());
+
+    act(() => {
+      result.current.openEditDialog({
+        id: 7,
+        ticker: 'AAPL',
+        quantity: 1,
+        buyPrice: 12,
+        buyDate: new Date().toISOString(),
+      });
+    });
+
+    act(() => {
+      result.current.setNewBuyDate(invalidDate);
+    });
+
+    act(() => {
+      result.current.onEditSubmit();
+    });
+
+    await waitFor(() => {
+      expect(result.current.buyDateError).toBe('Enter a valid buy date');
+    });
+    expect(mockedApi.put).not.toHaveBeenCalled();
+  });
+
+  it('requires sell price before closing a position', async () => {
+    mockedApi.get.mockResolvedValueOnce({
+      data: [
+        {
+          id: 1,
+          ticker: 'AAPL',
+          quantity: 1,
+          buyPrice: 10,
+          buyDate: new Date().toISOString(),
+        },
+      ],
+    } as never);
+
+    const { result } = renderHook(() => usePositionsPage(false), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(mockedApi.get).toHaveBeenCalled());
+
+    act(() => {
+      result.current.openCloseDialog({
+        id: 1,
+        ticker: 'AAPL',
+        quantity: 1,
+        buyPrice: 10,
+        buyDate: new Date().toISOString(),
+      });
+    });
+
+    act(() => {
+      result.current.setNewSellPrice('');
+    });
+
+    act(() => {
+      result.current.onCloseSubmit();
+    });
+
+    await waitFor(() => {
+      expect(result.current.sellPriceError).toBe('Sell price is required');
+    });
+    expect(mockedApi.put).not.toHaveBeenCalled();
+  });
+
+  it('allows zero as a sell price when closing a position', async () => {
+    mockedApi.get.mockResolvedValueOnce({
+      data: [
+        {
+          id: 1,
+          ticker: 'AAPL',
+          quantity: 1,
+          buyPrice: 10,
+          buyDate: new Date().toISOString(),
+        },
+      ],
+    } as never);
+
+    const { result } = renderHook(() => usePositionsPage(false), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(mockedApi.get).toHaveBeenCalled());
+
+    act(() => {
+      result.current.openCloseDialog({
+        id: 1,
+        ticker: 'AAPL',
+        quantity: 1,
+        buyPrice: 10,
+        buyDate: new Date().toISOString(),
+      });
+    });
+
+    act(() => {
+      result.current.setNewSellPrice('0');
+    });
+
+    act(() => {
+      result.current.onCloseSubmit();
+    });
+
+    await waitFor(() => {
+      expect(mockedApi.put).toHaveBeenCalledWith(
+        '/positions/1/close',
+        expect.objectContaining({
+          sellPrice: 0,
+        }),
+      );
+    });
+  });
+
+  it('requires a valid sell date before closing a position', async () => {
+    mockedApi.get.mockResolvedValueOnce({
+      data: [
+        {
+          id: 1,
+          ticker: 'AAPL',
+          quantity: 1,
+          buyPrice: 10,
+          buyDate: new Date().toISOString(),
+        },
+      ],
+    } as never);
+
+    const { result } = renderHook(() => usePositionsPage(false), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(mockedApi.get).toHaveBeenCalled());
+
+    act(() => {
+      result.current.openCloseDialog({
+        id: 1,
+        ticker: 'AAPL',
+        quantity: 1,
+        buyPrice: 10,
+        buyDate: new Date().toISOString(),
+      });
+    });
+
+    act(() => {
+      result.current.setNewSellPrice('5');
+      result.current.setNewSellDate(null);
+    });
+
+    act(() => {
+      result.current.onCloseSubmit();
+    });
+
+    await waitFor(() => {
+      expect(result.current.sellDateError).toBe('Sell date is required');
+    });
+    expect(mockedApi.put).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/portfolio/hooks/usePositionsPage.ts
+++ b/frontend/src/features/portfolio/hooks/usePositionsPage.ts
@@ -62,6 +62,11 @@ export type PositionsPageVM = {
   newSellPrice: string;
   newSellDate: Dayjs | null;
   tickerError: string;
+  quantityError: string;
+  buyPriceError: string;
+  buyDateError: string;
+  sellPriceError: string;
+  sellDateError: string;
 
   // Form setters
   setNewTicker: (v: string) => void;
@@ -98,6 +103,39 @@ export type PositionsPageVM = {
   closeToast: () => void;
 };
 
+const QUANTITY_ERROR_MESSAGE = 'Quantity must be greater than 0';
+const BUY_PRICE_REQUIRED_MESSAGE = 'Buy price is required';
+const BUY_PRICE_POSITIVE_MESSAGE = 'Buy price must be greater than 0';
+const BUY_DATE_REQUIRED_MESSAGE = 'Buy date is required';
+const BUY_DATE_INVALID_MESSAGE = 'Enter a valid buy date';
+const SELL_PRICE_REQUIRED_MESSAGE = 'Sell price is required';
+const SELL_DATE_REQUIRED_MESSAGE = 'Sell date is required';
+const SELL_DATE_INVALID_MESSAGE = 'Enter a valid sell date';
+
+function parsePositiveNumber(value: string): number | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return null;
+  }
+
+  return parsed;
+}
+
+function parseRequiredNumberAllowZero(value: string): number | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+
+  return parsed;
+}
+
 export function usePositionsPage(isMobile: boolean): PositionsPageVM {
   usePositionWS();
   const qc = useQueryClient();
@@ -117,6 +155,11 @@ export function usePositionsPage(isMobile: boolean): PositionsPageVM {
   const [newSellPrice, setNewSellPrice] = useState('');
   const [newSellDate, setNewSellDate] = useState<Dayjs | null>(dayjs());
   const [tickerError, setTickerError] = useState('');
+  const [quantityError, setQuantityError] = useState('');
+  const [buyPriceError, setBuyPriceError] = useState('');
+  const [buyDateError, setBuyDateError] = useState('');
+  const [sellPriceError, setSellPriceError] = useState('');
+  const [sellDateError, setSellDateError] = useState('');
 
   const [toast, setToast] = useState<ToastState>({ open: false, message: '', severity: 'success' });
   const showToast = (message: string, severity: ToastSeverity = 'success') => {
@@ -139,7 +182,6 @@ export function usePositionsPage(isMobile: boolean): PositionsPageVM {
   const quotesResult = useQuotes(tickers);
 
   const quotesArray = useMemo<RemoteQuote[]>(() => quotesResult.data ?? [], [quotesResult.data]);
-
   const quotesLoading = quotesResult.isLoading;
 
   const quotesMap = useMemo<Record<string, RemoteQuote>>(() => {
@@ -292,41 +334,171 @@ export function usePositionsPage(isMobile: boolean): PositionsPageVM {
     },
   });
 
+  const validateQuantity = (): number | null => {
+    const parsedQuantity = parsePositiveNumber(newQuantity);
+    if (parsedQuantity === null) {
+      setQuantityError(QUANTITY_ERROR_MESSAGE);
+      return null;
+    }
+
+    setQuantityError('');
+    return parsedQuantity;
+  };
+
+  const validateBuyPrice = (): number | null => {
+    const trimmed = newBuyPrice.trim();
+    if (!trimmed) {
+      setBuyPriceError(BUY_PRICE_REQUIRED_MESSAGE);
+      return null;
+    }
+
+    const parsedBuyPrice = parsePositiveNumber(trimmed);
+    if (parsedBuyPrice === null) {
+      setBuyPriceError(BUY_PRICE_POSITIVE_MESSAGE);
+      return null;
+    }
+
+    setBuyPriceError('');
+    return parsedBuyPrice;
+  };
+
+  const validateBuyDate = (): string | null => {
+    if (newBuyDate === null) {
+      setBuyDateError(BUY_DATE_REQUIRED_MESSAGE);
+      return null;
+    }
+    if (!newBuyDate.isValid()) {
+      setBuyDateError(BUY_DATE_INVALID_MESSAGE);
+      return null;
+    }
+
+    setBuyDateError('');
+    return newBuyDate.toISOString();
+  };
+
+  const validateSellPrice = (): number | null => {
+    const trimmed = newSellPrice.trim();
+    if (!trimmed) {
+      setSellPriceError(SELL_PRICE_REQUIRED_MESSAGE);
+      return null;
+    }
+
+    const parsedSellPrice = parseRequiredNumberAllowZero(trimmed);
+    if (parsedSellPrice === null) {
+      setSellPriceError(SELL_PRICE_REQUIRED_MESSAGE);
+      return null;
+    }
+
+    setSellPriceError('');
+    return parsedSellPrice;
+  };
+
+  const validateSellDate = (): string | null => {
+    if (newSellDate === null) {
+      setSellDateError(SELL_DATE_REQUIRED_MESSAGE);
+      return null;
+    }
+
+    if (!newSellDate.isValid()) {
+      setSellDateError(SELL_DATE_INVALID_MESSAGE);
+      return null;
+    }
+
+    setSellDateError('');
+    return newSellDate.toISOString();
+  };
+
   const onAddSubmit = () => {
     setTickerError('');
+
     const sym = normalizeSymbol(newTicker);
     if (!sym) {
       setTickerError('Ticker is required');
       return;
     }
 
+    const quantity = validateQuantity();
+    if (quantity === null) {
+      return;
+    }
+
+    const buyPrice = validateBuyPrice();
+    if (buyPrice === null) {
+      return;
+    }
+
+    const buyDate = validateBuyDate();
+    if (buyDate === null) {
+      return;
+    }
+
     addPosition.mutate({
       ticker: sym,
-      quantity: Number(newQuantity),
-      buyPrice: Number(newBuyPrice),
-      buyDate: newBuyDate?.toISOString(),
+      quantity,
+      buyPrice,
+      buyDate,
     });
   };
 
   const onCloseSubmit = () => {
     if (!selected) return;
+
+    const sellPrice = validateSellPrice();
+    if (sellPrice === null) {
+      return;
+    }
+
+    const sellDate = validateSellDate();
+    if (sellDate === null) {
+      return;
+    }
+
     closePosition.mutate({
       id: selected.id,
-      sellPrice: Number(newSellPrice),
-      sellDate: newSellDate?.toISOString(),
+      sellPrice,
+      sellDate,
     });
   };
 
   const onEditSubmit = () => {
     if (!selected) return;
+
+    const quantity = validateQuantity();
+    if (quantity === null) {
+      return;
+    }
+
+    const buyPrice = validateBuyPrice();
+    if (buyPrice === null) {
+      return;
+    }
+
+    const buyDate = validateBuyDate();
+    if (buyDate === null) {
+      return;
+    }
+
+    let closedFields: { sellPrice?: number; sellDate?: string } = {};
+    if (tab === 'closed') {
+      const sellPrice = validateSellPrice();
+      if (sellPrice === null) {
+        return;
+      }
+
+      const sellDate = validateSellDate();
+      if (sellDate === null) {
+        return;
+      }
+
+      closedFields = { sellPrice, sellDate };
+    }
+
     editPosition.mutate({
       id: selected.id,
-      quantity: Number(newQuantity),
-      buyPrice: Number(newBuyPrice),
-      buyDate: newBuyDate?.toISOString(),
-      ...(tab === 'closed'
-        ? { sellPrice: Number(newSellPrice), sellDate: newSellDate?.toISOString() }
-        : {}),
+      quantity,
+      buyPrice,
+      buyDate,
+      ...closedFields,
     });
   };
 
@@ -341,6 +513,9 @@ export function usePositionsPage(isMobile: boolean): PositionsPageVM {
     setNewBuyPrice('');
     setNewBuyDate(dayjs());
     setTickerError('');
+    setQuantityError('');
+    setBuyPriceError('');
+    setBuyDateError('');
     setAddOpen(true);
   };
 
@@ -353,6 +528,8 @@ export function usePositionsPage(isMobile: boolean): PositionsPageVM {
     setSelected(pos);
     setNewSellPrice('');
     setNewSellDate(dayjs());
+    setSellPriceError('');
+    setSellDateError('');
     setCloseOpen(true);
   };
 
@@ -361,13 +538,83 @@ export function usePositionsPage(isMobile: boolean): PositionsPageVM {
     setNewQuantity(String(pos.quantity));
     setNewBuyPrice(String(pos.buyPrice));
     setNewBuyDate(dayjs(pos.buyDate));
+    setQuantityError('');
+    setBuyPriceError('');
+    setBuyDateError('');
+    setSellPriceError('');
+    setSellDateError('');
 
     if (tab === 'closed') {
-      if (pos.sellDate) setNewSellDate(dayjs(pos.sellDate));
-      if (isFiniteNumber(pos.sellPrice)) setNewSellPrice(String(pos.sellPrice));
+      setNewSellDate(pos.sellDate ? dayjs(pos.sellDate) : dayjs());
+      setNewSellPrice(isFiniteNumber(pos.sellPrice) ? String(pos.sellPrice) : '');
     }
 
     setEditOpen(true);
+  };
+
+  const handleSetNewTicker = (value: string) => {
+    setNewTicker(value);
+    if (value.trim()) {
+      setTickerError('');
+    }
+  };
+
+  const handleSetNewQuantity = (value: string) => {
+    setNewQuantity(value);
+
+    if (!value.trim()) {
+      setQuantityError('');
+      return;
+    }
+
+    const parsed = parsePositiveNumber(value);
+    setQuantityError(parsed === null ? QUANTITY_ERROR_MESSAGE : '');
+  };
+
+  const handleSetNewBuyPrice = (value: string) => {
+    setNewBuyPrice(value);
+
+    if (!value.trim()) {
+      setBuyPriceError('');
+      return;
+    }
+
+    const parsed = parsePositiveNumber(value);
+    setBuyPriceError(parsed === null ? BUY_PRICE_POSITIVE_MESSAGE : '');
+  };
+
+  const handleSetNewBuyDate = (value: Dayjs | null) => {
+    setNewBuyDate(value);
+
+    if (value === null) {
+      setBuyDateError('');
+      return;
+    }
+
+    setBuyDateError(value.isValid() ? '' : BUY_DATE_INVALID_MESSAGE);
+  };
+
+  const handleSetNewSellPrice = (value: string) => {
+    setNewSellPrice(value);
+
+    if (!value.trim()) {
+      setSellPriceError('');
+      return;
+    }
+
+    const parsed = parseRequiredNumberAllowZero(value);
+    setSellPriceError(parsed === null ? SELL_PRICE_REQUIRED_MESSAGE : '');
+  };
+
+  const handleSetNewSellDate = (value: Dayjs | null) => {
+    setNewSellDate(value);
+
+    if (value === null) {
+      setSellDateError('');
+      return;
+    }
+
+    setSellDateError(value.isValid() ? '' : SELL_DATE_INVALID_MESSAGE);
   };
 
   return {
@@ -400,21 +647,43 @@ export function usePositionsPage(isMobile: boolean): PositionsPageVM {
     newSellPrice,
     newSellDate,
     tickerError,
+    quantityError,
+    buyPriceError,
+    buyDateError,
+    sellPriceError,
+    sellDateError,
 
-    setNewTicker,
-    setNewQuantity,
-    setNewBuyPrice,
-    setNewBuyDate,
-    setNewSellPrice,
-    setNewSellDate,
+    setNewTicker: handleSetNewTicker,
+    setNewQuantity: handleSetNewQuantity,
+    setNewBuyPrice: handleSetNewBuyPrice,
+    setNewBuyDate: handleSetNewBuyDate,
+    setNewSellPrice: handleSetNewSellPrice,
+    setNewSellDate: handleSetNewSellDate,
 
     openAddDialog,
     openCloseDialog,
     openEditDialog,
     openDeleteDialog,
-    closeAddDialog: () => setAddOpen(false),
-    closeCloseDialog: () => setCloseOpen(false),
-    closeEditDialog: () => setEditOpen(false),
+    closeAddDialog: () => {
+      setAddOpen(false);
+      setTickerError('');
+      setQuantityError('');
+      setBuyPriceError('');
+      setBuyDateError('');
+    },
+    closeCloseDialog: () => {
+      setCloseOpen(false);
+      setSellPriceError('');
+      setSellDateError('');
+    },
+    closeEditDialog: () => {
+      setEditOpen(false);
+      setQuantityError('');
+      setBuyPriceError('');
+      setBuyDateError('');
+      setSellPriceError('');
+      setSellDateError('');
+    },
     closeDeleteDialog: () => setDeleteOpen(false),
 
     onAddSubmit,

--- a/frontend/src/features/portfolio/pages/PositionsPage.test.tsx
+++ b/frontend/src/features/portfolio/pages/PositionsPage.test.tsx
@@ -98,6 +98,11 @@ function baseVm(overrides: VmOverrides = {}): UsePositionsPageVm {
     newSellPrice: '',
     newSellDate: null,
     tickerError: '',
+    quantityError: '',
+    buyPriceError: '',
+    buyDateError: '',
+    sellPriceError: '',
+    sellDateError: '',
 
     setNewTicker: jest.fn(),
     setNewQuantity: jest.fn(),

--- a/frontend/src/features/portfolio/pages/PositionsPage.tsx
+++ b/frontend/src/features/portfolio/pages/PositionsPage.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import Button from '@mui/material/Button';
 import ButtonGroup from '@mui/material/ButtonGroup';
-import Typography from '@mui/material/Typography';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
 
 import {
   InlineInfoAlert,
+  MutedHelperText,
   PageCard,
   PositionsTabGroupWrap,
   SectionContent,
@@ -117,9 +117,9 @@ const PositionsPage: React.FC = () => {
             )}
 
             {vm.positions.length > 0 && vm.tab === 'closed' && vm.isMobile ? (
-              <Typography variant="body2" color="text.secondary" sx={{ mt: 2 }}>
+              <MutedHelperText variant="body2">
                 Totals are shown above for quick reference.
-              </Typography>
+              </MutedHelperText>
             ) : null}
           </SectionContent>
         </PageCard>
@@ -143,6 +143,11 @@ const PositionsPage: React.FC = () => {
         newSellPrice={vm.newSellPrice}
         newSellDate={vm.newSellDate}
         tickerError={vm.tickerError}
+        quantityError={vm.quantityError}
+        buyPriceError={vm.buyPriceError}
+        buyDateError={vm.buyDateError}
+        sellPriceError={vm.sellPriceError}
+        sellDateError={vm.sellDateError}
         setNewTicker={vm.setNewTicker}
         setNewQuantity={vm.setNewQuantity}
         setNewBuyPrice={vm.setNewBuyPrice}

--- a/frontend/src/shared/ui/layout/Styled.tsx
+++ b/frontend/src/shared/ui/layout/Styled.tsx
@@ -647,17 +647,22 @@ export const KpiChip = styled(Chip)(({ theme }) => ({
 }));
 
 export const KpiInfoButton = styled(IconButton)(({ theme }) => ({
-  width: 28,
-  height: 28,
+  width: 18,
+  height: 18,
   padding: 0,
+  marginLeft: theme.spacing(0.25),
   borderRadius: 999,
-  border: `1px solid ${alpha(theme.palette.text.primary, 0.1)}`,
-  backgroundColor: alpha(theme.palette.text.primary, 0.03),
-  transition: 'background-color 140ms ease, border-color 140ms ease, transform 140ms ease',
+  color: alpha(theme.palette.text.secondary, 0.7),
+  backgroundColor: 'transparent',
+  border: 'none',
+  fontSize: 16,
   '&:hover': {
-    backgroundColor: alpha(theme.palette.text.primary, 0.06),
-    borderColor: alpha(theme.palette.text.primary, 0.16),
-    transform: 'translateY(-1px)',
+    backgroundColor: 'transparent',
+    color: theme.palette.text.secondary,
+  },
+  '&.Mui-focusVisible': {
+    outline: 'none',
+    backgroundColor: 'transparent',
   },
 }));
 
@@ -704,6 +709,11 @@ export const PositionsActions = styled(Box)(({ theme }) => ({
   justifyContent: 'center',
   gap: theme.spacing(1),
   flexWrap: 'wrap',
+}));
+
+export const MutedHelperText = styled(Typography)(({ theme }) => ({
+  marginTop: theme.spacing(2),
+  color: theme.palette.text.secondary,
 }));
 
 export const TickerCell = styled(Box)(({ theme }) => ({

--- a/services/positions/app/api/schemas.py
+++ b/services/positions/app/api/schemas.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from app.db.models import Position
 
@@ -49,20 +49,20 @@ class AuthUpdatePasswordRequest(BaseModel):
 
 class PositionCreateRequest(BaseModel):
     ticker: str
-    quantity: float
-    buyPrice: float
-    buyDate: datetime | None = None
+    quantity: float = Field(..., gt=0)
+    buyPrice: float = Field(..., gt=0)
+    buyDate: datetime
 
 
 class PositionCloseRequest(BaseModel):
     sellPrice: float
-    sellDate: datetime | None = None
+    sellDate: datetime
 
 
 class PositionUpdateRequest(BaseModel):
-    quantity: float
-    buyPrice: float
-    buyDate: datetime | None = None
+    quantity: float = Field(..., gt=0)
+    buyPrice: float = Field(..., gt=0)
+    buyDate: datetime
     sellPrice: float | None = None
     sellDate: datetime | None = None
 

--- a/services/positions/app/core/config.py
+++ b/services/positions/app/core/config.py
@@ -68,6 +68,7 @@ class Settings(BaseSettings):
             return [o for o in origins if o]
         return [self.frontend_origin]
 
+
 @lru_cache
 def get_settings() -> Settings:
     """

--- a/services/positions/tests/test_positions.py
+++ b/services/positions/tests/test_positions.py
@@ -2,18 +2,40 @@ from __future__ import annotations
 
 from fastapi.testclient import TestClient
 
+VALID_BUY_DATE = "2026-03-06T00:00:00"
+VALID_SELL_DATE = "2026-03-07T00:00:00"
+
 
 def test_list_open_and_closed(client: TestClient, set_user_id):
     set_user_id(7)
 
-    r1 = client.post("/api/positions", json={"ticker": "AAPL", "quantity": 1, "buyPrice": 10.0})
+    r1 = client.post(
+        "/api/positions",
+        json={
+            "ticker": "AAPL",
+            "quantity": 1,
+            "buyPrice": 10.0,
+            "buyDate": VALID_BUY_DATE,
+        },
+    )
     assert r1.status_code == 201
     pid = r1.json()["id"]
 
-    r_close = client.put(f"/api/positions/{pid}/close", json={"sellPrice": 12.0})
+    r_close = client.put(
+        f"/api/positions/{pid}/close",
+        json={"sellPrice": 12.0, "sellDate": VALID_SELL_DATE},
+    )
     assert r_close.status_code == 200
 
-    r2 = client.post("/api/positions", json={"ticker": "MSFT", "quantity": 2, "buyPrice": 5.0})
+    r2 = client.post(
+        "/api/positions",
+        json={
+            "ticker": "MSFT",
+            "quantity": 2,
+            "buyPrice": 5.0,
+            "buyDate": VALID_BUY_DATE,
+        },
+    )
     assert r2.status_code == 201
 
     r_open = client.get("/api/positions?status=open")
@@ -27,22 +49,181 @@ def test_list_open_and_closed(client: TestClient, set_user_id):
 
 def test_create_position_validation(client: TestClient, set_user_id):
     set_user_id(1)
-    r = client.post("/api/positions", json={"ticker": "   ", "quantity": 1, "buyPrice": 10})
+    r = client.post(
+        "/api/positions",
+        json={
+            "ticker": "   ",
+            "quantity": 1,
+            "buyPrice": 10,
+            "buyDate": VALID_BUY_DATE,
+        },
+    )
     assert r.status_code == 400
+
+
+def test_create_position_rejects_non_positive_quantity(client: TestClient, set_user_id):
+    set_user_id(1)
+
+    zero = client.post(
+        "/api/positions",
+        json={
+            "ticker": "AAPL",
+            "quantity": 0,
+            "buyPrice": 10.0,
+            "buyDate": VALID_BUY_DATE,
+        },
+    )
+    assert zero.status_code == 422
+
+    negative = client.post(
+        "/api/positions",
+        json={
+            "ticker": "AAPL",
+            "quantity": -1,
+            "buyPrice": 10.0,
+            "buyDate": VALID_BUY_DATE,
+        },
+    )
+    assert negative.status_code == 422
+
+
+def test_create_position_rejects_missing_buy_price(client: TestClient, set_user_id):
+    set_user_id(1)
+
+    r = client.post(
+        "/api/positions",
+        json={"ticker": "AAPL", "quantity": 1, "buyDate": VALID_BUY_DATE},
+    )
+    assert r.status_code == 422
+
+
+def test_create_position_rejects_non_positive_buy_price(client: TestClient, set_user_id):
+    set_user_id(1)
+
+    zero = client.post(
+        "/api/positions",
+        json={
+            "ticker": "AAPL",
+            "quantity": 1,
+            "buyPrice": 0,
+            "buyDate": VALID_BUY_DATE,
+        },
+    )
+    assert zero.status_code == 422
+
+    negative = client.post(
+        "/api/positions",
+        json={
+            "ticker": "AAPL",
+            "quantity": 1,
+            "buyPrice": -10,
+            "buyDate": VALID_BUY_DATE,
+        },
+    )
+    assert negative.status_code == 422
+
+
+def test_update_position_rejects_non_positive_quantity(client: TestClient, set_user_id):
+    set_user_id(1)
+
+    created = client.post(
+        "/api/positions",
+        json={
+            "ticker": "AAPL",
+            "quantity": 1,
+            "buyPrice": 10.0,
+            "buyDate": VALID_BUY_DATE,
+        },
+    )
+    assert created.status_code == 201
+    pid = created.json()["id"]
+
+    zero = client.put(
+        f"/api/positions/{pid}",
+        json={"quantity": 0, "buyPrice": 11.0, "buyDate": VALID_BUY_DATE},
+    )
+    assert zero.status_code == 422
+
+    negative = client.put(
+        f"/api/positions/{pid}",
+        json={"quantity": -2, "buyPrice": 11.0, "buyDate": VALID_BUY_DATE},
+    )
+    assert negative.status_code == 422
+
+
+def test_update_position_rejects_missing_buy_price(client: TestClient, set_user_id):
+    set_user_id(1)
+
+    created = client.post(
+        "/api/positions",
+        json={
+            "ticker": "AAPL",
+            "quantity": 1,
+            "buyPrice": 10.0,
+            "buyDate": VALID_BUY_DATE,
+        },
+    )
+    assert created.status_code == 201
+    pid = created.json()["id"]
+
+    r = client.put(
+        f"/api/positions/{pid}",
+        json={"quantity": 2, "buyDate": VALID_BUY_DATE},
+    )
+    assert r.status_code == 422
+
+
+def test_update_position_rejects_non_positive_buy_price(client: TestClient, set_user_id):
+    set_user_id(1)
+
+    created = client.post(
+        "/api/positions",
+        json={
+            "ticker": "AAPL",
+            "quantity": 1,
+            "buyPrice": 10.0,
+            "buyDate": VALID_BUY_DATE,
+        },
+    )
+    assert created.status_code == 201
+    pid = created.json()["id"]
+
+    zero = client.put(
+        f"/api/positions/{pid}",
+        json={"quantity": 2, "buyPrice": 0, "buyDate": VALID_BUY_DATE},
+    )
+    assert zero.status_code == 422
+
+    negative = client.put(
+        f"/api/positions/{pid}",
+        json={"quantity": 2, "buyPrice": -5, "buyDate": VALID_BUY_DATE},
+    )
+    assert negative.status_code == 422
 
 
 def test_create_close_update_delete_happy_path(client: TestClient, set_user_id, emitter):
     set_user_id(1)
 
-    payload = {"ticker": "aapl", "quantity": 1, "buyPrice": 10.0}
+    payload = {
+        "ticker": "aapl",
+        "quantity": 1,
+        "buyPrice": 10.0,
+        "buyDate": VALID_BUY_DATE,
+    }
     r_create = client.post("/api/positions", json=payload)
     assert r_create.status_code == 201
     pid = r_create.json()["id"]
 
-    r_update = client.put(f"/api/positions/{pid}", json={"quantity": 3, "buyPrice": 11.0})
+    r_update = client.put(
+        f"/api/positions/{pid}",
+        json={"quantity": 3, "buyPrice": 11.0, "buyDate": VALID_BUY_DATE},
+    )
     assert r_update.status_code == 200
 
-    r_close = client.put(f"/api/positions/{pid}/close", json={"sellPrice": 20.0})
+    r_close = client.put(
+        f"/api/positions/{pid}/close",
+        json={"sellPrice": 20.0, "sellDate": VALID_SELL_DATE},
+    )
     assert r_close.status_code == 200
 
     r_delete = client.delete(f"/api/positions/{pid}")
@@ -55,15 +236,98 @@ def test_create_close_update_delete_happy_path(client: TestClient, set_user_id, 
     assert "position:deleted" in evts
 
 
+def test_close_position_rejects_missing_sell_price(client: TestClient, set_user_id):
+    set_user_id(1)
+
+    created = client.post(
+        "/api/positions",
+        json={
+            "ticker": "AAPL",
+            "quantity": 1,
+            "buyPrice": 10.0,
+            "buyDate": VALID_BUY_DATE,
+        },
+    )
+    assert created.status_code == 201
+    pid = created.json()["id"]
+
+    r = client.put(
+        f"/api/positions/{pid}/close",
+        json={"sellDate": VALID_SELL_DATE},
+    )
+    assert r.status_code == 422
+
+
+def test_close_position_allows_zero_sell_price(client: TestClient, set_user_id):
+    set_user_id(1)
+
+    created = client.post(
+        "/api/positions",
+        json={
+            "ticker": "AAPL",
+            "quantity": 1,
+            "buyPrice": 10.0,
+            "buyDate": VALID_BUY_DATE,
+        },
+    )
+    assert created.status_code == 201
+    pid = created.json()["id"]
+
+    r = client.put(
+        f"/api/positions/{pid}/close",
+        json={"sellPrice": 0, "sellDate": VALID_SELL_DATE},
+    )
+    assert r.status_code == 200
+    assert r.json()["sellPrice"] == 0.0
+
+
+def test_close_position_rejects_missing_sell_date(client: TestClient, set_user_id):
+    set_user_id(1)
+
+    created = client.post(
+        "/api/positions",
+        json={
+            "ticker": "AAPL",
+            "quantity": 1,
+            "buyPrice": 10.0,
+            "buyDate": VALID_BUY_DATE,
+        },
+    )
+    assert created.status_code == 201
+    pid = created.json()["id"]
+
+    r = client.put(
+        f"/api/positions/{pid}/close",
+        json={"sellPrice": 5.0},
+    )
+    assert r.status_code == 422
+
+
+def test_create_position_rejects_missing_buy_date(client: TestClient, set_user_id):
+    set_user_id(1)
+
+    r = client.post(
+        "/api/positions",
+        json={"ticker": "AAPL", "quantity": 1, "buyPrice": 10.0},
+    )
+    assert r.status_code == 422
+
+
 def test_close_not_found(client: TestClient, set_user_id):
     set_user_id(1)
-    r = client.put("/api/positions/999/close", json={"sellPrice": 10.0})
+    r = client.put(
+        "/api/positions/999/close",
+        json={"sellPrice": 10.0, "sellDate": VALID_SELL_DATE},
+    )
     assert r.status_code == 404
 
 
 def test_update_not_found(client: TestClient, set_user_id):
     set_user_id(1)
-    r = client.put("/api/positions/999", json={"quantity": 1, "buyPrice": 1.0})
+    r = client.put(
+        "/api/positions/999",
+        json={"quantity": 1, "buyPrice": 1.0, "buyDate": VALID_BUY_DATE},
+    )
     assert r.status_code == 404
 
 

--- a/services/positions/tests/test_routes_branches.py
+++ b/services/positions/tests/test_routes_branches.py
@@ -11,6 +11,9 @@ import app.api.routes as routes_mod
 from app.core.config import Settings
 from app.db.engine import get_session
 
+VALID_BUY_DATE = datetime(2026, 3, 6, tzinfo=timezone.utc).isoformat()
+VALID_SELL_DATE = datetime(2026, 3, 7, tzinfo=timezone.utc).isoformat()
+
 
 class DummySession:
     """Marker session; repositories are faked in tests."""
@@ -68,17 +71,163 @@ def test_list_positions_rejects_invalid_status(client: TestClient):
 def test_create_position_rejects_blank_ticker(client: TestClient):
     r = client.post(
         "/api/positions",
-        json={"ticker": "   ", "quantity": 1.0, "buyPrice": 10.0, "buyDate": None},
+        json={
+            "ticker": "   ",
+            "quantity": 1.0,
+            "buyPrice": 10.0,
+            "buyDate": VALID_BUY_DATE,
+        },
     )
     assert r.status_code == 400
+
+
+def test_create_position_rejects_non_positive_quantity(client: TestClient):
+    r = client.post(
+        "/api/positions",
+        json={
+            "ticker": "AAPL",
+            "quantity": 0,
+            "buyPrice": 10.0,
+            "buyDate": VALID_BUY_DATE,
+        },
+    )
+    assert r.status_code == 422
+
+
+def test_create_position_rejects_non_positive_buy_price(client: TestClient):
+    r = client.post(
+        "/api/positions",
+        json={
+            "ticker": "AAPL",
+            "quantity": 1.0,
+            "buyPrice": 0,
+            "buyDate": VALID_BUY_DATE,
+        },
+    )
+    assert r.status_code == 422
+
+
+def test_update_position_rejects_non_positive_quantity(client: TestClient):
+    created = client.post(
+        "/api/positions",
+        json={
+            "ticker": "AAPL",
+            "quantity": 1.0,
+            "buyPrice": 10.0,
+            "buyDate": VALID_BUY_DATE,
+        },
+    )
+    assert created.status_code == 201
+    pos_id = created.json()["id"]
+
+    r = client.put(
+        f"/api/positions/{pos_id}",
+        json={
+            "quantity": -1.0,
+            "buyPrice": 11.0,
+            "buyDate": VALID_BUY_DATE,
+            "sellPrice": None,
+            "sellDate": None,
+        },
+    )
+    assert r.status_code == 422
+
+
+def test_update_position_rejects_non_positive_buy_price(client: TestClient):
+    created = client.post(
+        "/api/positions",
+        json={
+            "ticker": "AAPL",
+            "quantity": 1.0,
+            "buyPrice": 10.0,
+            "buyDate": VALID_BUY_DATE,
+        },
+    )
+    assert created.status_code == 201
+    pos_id = created.json()["id"]
+
+    r = client.put(
+        f"/api/positions/{pos_id}",
+        json={
+            "quantity": 2.0,
+            "buyPrice": -11.0,
+            "buyDate": VALID_BUY_DATE,
+            "sellPrice": None,
+            "sellDate": None,
+        },
+    )
+    assert r.status_code == 422
 
 
 def test_close_position_404_when_missing(client: TestClient):
     r = client.put(
         "/api/positions/999/close",
-        json={"sellPrice": 12.0, "sellDate": None},
+        json={"sellPrice": 12.0, "sellDate": VALID_SELL_DATE},
     )
     assert r.status_code == 404
+
+
+def test_close_position_rejects_missing_sell_price(client: TestClient):
+    created = client.post(
+        "/api/positions",
+        json={
+            "ticker": "AAPL",
+            "quantity": 1.0,
+            "buyPrice": 10.0,
+            "buyDate": VALID_BUY_DATE,
+        },
+    )
+    assert created.status_code == 201
+    pos_id = created.json()["id"]
+
+    r = client.put(
+        f"/api/positions/{pos_id}/close",
+        json={"sellDate": VALID_SELL_DATE},
+    )
+    assert r.status_code == 422
+
+
+def test_close_position_allows_zero_sell_price(client: TestClient):
+    created = client.post(
+        "/api/positions",
+        json={
+            "ticker": "AAPL",
+            "quantity": 1.0,
+            "buyPrice": 10.0,
+            "buyDate": VALID_BUY_DATE,
+        },
+    )
+    assert created.status_code == 201
+    pos_id = created.json()["id"]
+
+    r = client.put(
+        f"/api/positions/{pos_id}/close",
+        json={
+            "sellPrice": 0,
+            "sellDate": VALID_SELL_DATE,
+        },
+    )
+    assert r.status_code == 200
+
+
+def test_close_position_rejects_missing_sell_date(client: TestClient):
+    created = client.post(
+        "/api/positions",
+        json={
+            "ticker": "AAPL",
+            "quantity": 1.0,
+            "buyPrice": 10.0,
+            "buyDate": VALID_BUY_DATE,
+        },
+    )
+    assert created.status_code == 201
+    pos_id = created.json()["id"]
+
+    r = client.put(
+        f"/api/positions/{pos_id}/close",
+        json={"sellPrice": 10.0},
+    )
+    assert r.status_code == 422
 
 
 def test_update_position_404_when_missing(client: TestClient):
@@ -87,7 +236,7 @@ def test_update_position_404_when_missing(client: TestClient):
         json={
             "quantity": 2.0,
             "buyPrice": 11.0,
-            "buyDate": None,
+            "buyDate": VALID_BUY_DATE,
             "sellPrice": None,
             "sellDate": None,
         },
@@ -107,7 +256,7 @@ def test_delete_position_emits_event(client: TestClient, emitter):
             "ticker": "aapl",
             "quantity": 1.0,
             "buyPrice": 10.0,
-            "buyDate": datetime.now(timezone.utc).isoformat(),
+            "buyDate": VALID_BUY_DATE,
         },
     )
     assert created.status_code == 201

--- a/services/positions/tests/test_routes_quote_prefetch_failure.py
+++ b/services/positions/tests/test_routes_quote_prefetch_failure.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Any
 
 import pytest
@@ -9,6 +10,8 @@ from fastapi.testclient import TestClient
 import app.api.routes as routes_mod
 from app.core.config import Settings
 from app.db.engine import get_session
+
+VALID_BUY_DATE = datetime(2026, 3, 6, tzinfo=timezone.utc).isoformat()
 
 
 class _Session:
@@ -75,7 +78,12 @@ def test_create_position_quote_prefetch_exception_rolls_back(
 
     r = c.post(
         "/api/positions",
-        json={"ticker": "AAPL", "quantity": 1.0, "buyPrice": 10.0, "buyDate": None},
+        json={
+            "ticker": "AAPL",
+            "quantity": 1.0,
+            "buyPrice": 10.0,
+            "buyDate": VALID_BUY_DATE,
+        },
     )
     assert r.status_code == 201
     assert session.rollbacks == 1


### PR DESCRIPTION
## Summary of Changes

This pull request resolves multiple validation gaps in the portfolio positions workflow that previously allowed invalid position data to be submitted when creating, editing, or closing positions.

The following issues were addressed:

-   Users could enter negative values for quantity when adding a position.
-   Users could close a position without entering a sell price, which silently defaulted to `0`.
-   Users could submit invalid or malformed trade dates when opening or closing a position (for example `DD/03/2026` or `03/MM/2021`).
-   In some cases the form prevented submission but did not show a clear inline validation message, leaving the user without guidance.
-   A TypeScript compilation failure occurred in the `PositionDialogs` component due to unsupported polymorphic usage of the `component` prop on a styled `Box` wrapper.

This pull request strengthens validation across the portfolio workflow to ensure portfolio data integrity and improves the user experience by providing clear validation feedback.

Key improvements include:

-   Enforcing strict validation rules for quantity, prices, and trade dates.
-   Preventing negative quantities from being submitted.
-   Requiring users to explicitly enter a sell price when closing a position.
-   Rejecting malformed or empty trade dates.
-   Adding clear inline validation messages for invalid input fields.
-   Introducing helpful tooltips that explain each input requirement.
-   Refactoring dialog styling to remove inline styles and use reusable styled components.
-   Fixing the `PositionDialogs` TypeScript typing issue by replacing a styled `Box` wrapper with a styled `span` element.
-   Adding automated tests to validate form behavior and prevent regressions in portfolio position validation.

These changes improve data integrity, strengthen type safety, and align the frontend validation behavior with production-grade expectations.

------------------------------------------------------------------------

## Related Issue

Fixes #12 

------------------------------------------------------------------------

## How Has This Been Tested?

### Manual Testing

The portfolio workflow was tested through the UI to verify validation behavior.

Test scenarios included:

-   Adding a position with:
    -   Negative quantity
    -   Missing buy price
    -   Invalid or empty date
-   Closing a position without entering a sell price
-   Entering malformed date values in the date input field
-   Editing existing positions to ensure validation behaves consistently

Verified:

-   Negative quantities are rejected.
-   Buy price must be greater than `0`.
-   Closing a position requires a sell price.
-   Invalid or malformed dates are rejected.
-   Inline validation messages are displayed for invalid inputs.
-   Dialog tooltips clearly explain field requirements.

------------------------------------------------------------------------

### Automated Testing

#### Frontend

Quality checks and tests were executed:

    yarn lint
    yarn typecheck
    yarn test

Results:

-   ESLint passed
-   TypeScript type checking passed
-   All Jest tests passed
-   New test coverage added to verify validation behavior and guard against regressions in the portfolio position workflow

------------------------------------------------------------------------

#### Backend

Validation and API tests were executed for the positions service:

    python -m black . --check
    python -m ruff check .
    python -m pytest

Results:

-   Black formatting check passed
-   Ruff lint checks passed
-   All pytest tests passed

------------------------------------------------------------------------

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] Backend and frontend quality checks pass
-   [x] My changes generate no new warnings or console errors