### PR TITLE
feat(news): improve article relevance filtering and ranking

### DIFF
--- a/services/news/app/api/routes.py
+++ b/services/news/app/api/routes.py
@@ -47,7 +47,12 @@ def get_news(
         return []
 
     try:
-        items = fetch_articles_for_symbols(client, syms, settings.per_symbol_limit)
+        items = fetch_articles_for_symbols(
+            client=client,
+            symbols=syms,
+            per_symbol_limit=settings.per_symbol_limit,
+            minimum_score=settings.minimum_article_score,
+        )
     except RuntimeError as exc:
         raise HTTPException(status_code=502, detail="Upstream news provider unavailable") from exc
     except Exception as exc:

--- a/services/news/app/clients/newsapi.py
+++ b/services/news/app/clients/newsapi.py
@@ -30,18 +30,21 @@ class NewsApiClient:
     def close(self) -> None:
         self._http.close()
 
-    def fetch_recent(self, symbol: str, limit: int) -> list[NewsApiArticle]:
+    def fetch_recent(self, query: str, limit: int) -> list[NewsApiArticle]:
         params: Mapping[str, str | int] = {
-            "q": symbol,
+            "q": query,
             "apiKey": self._api_key,
             "pageSize": int(limit),
-            "sortBy": "publishedAt",
+            "sortBy": "relevancy",
             "language": "en",
+            "searchIn": "title,description",
         }
 
         resp = self._http.get(NEWSAPI_EVERYTHING_URL, params=params, timeout=self._timeout)
         if resp.status_code != 200:
-            log.warning("NewsAPI non-200 for %s: %s %s", symbol, resp.status_code, resp.text[:200])
+            log.warning(
+                "NewsAPI non-200 for query=%s: %s %s", query, resp.status_code, resp.text[:200]
+            )
             raise RuntimeError(f"NewsAPI error ({resp.status_code})")
 
         data = resp.json()

--- a/services/news/app/core/config.py
+++ b/services/news/app/core/config.py
@@ -41,8 +41,9 @@ class Settings(BaseSettings):
 
     port: int = Field(default=6500, validation_alias="NEWS_SERVICE_PORT")
 
-    per_symbol_limit: int = Field(default=5, validation_alias="NEWS_PER_SYMBOL_LIMIT")
+    per_symbol_limit: int = Field(default=8, validation_alias="NEWS_PER_SYMBOL_LIMIT")
     request_timeout_seconds: float = Field(default=5.0, validation_alias="NEWS_TIMEOUT_SECONDS")
+    minimum_article_score: int = Field(default=3, validation_alias="NEWS_MIN_ARTICLE_SCORE")
 
     log_level: str = Field(default="INFO", validation_alias="LOG_LEVEL")
 
@@ -51,6 +52,7 @@ class Settings(BaseSettings):
         if self.frontend_origins_csv:
             return _split_csv(self.frontend_origins_csv)
         return [self.frontend_origin]
+
 
 @lru_cache
 def get_settings() -> Settings:

--- a/services/news/app/services/news.py
+++ b/services/news/app/services/news.py
@@ -1,6 +1,73 @@
 from __future__ import annotations
 
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from urllib.parse import urlparse
+
 from app.clients.newsapi import NewsApiArticle, NewsApiClient
+
+FINANCE_TERMS = {
+    "stock",
+    "stocks",
+    "share",
+    "shares",
+    "market",
+    "markets",
+    "earnings",
+    "revenue",
+    "profit",
+    "profits",
+    "analyst",
+    "analysts",
+    "rating",
+    "ratings",
+    "price target",
+    "forecast",
+    "guidance",
+    "valuation",
+    "investor",
+    "investors",
+    "nasdaq",
+    "nyse",
+    "dividend",
+    "business",
+    "company",
+    "companies",
+}
+
+GARBAGE_PATTERNS = [
+    r"\b1080p\b",
+    r"\b720p\b",
+    r"\b2160p\b",
+    r"\bweb[- ]?dl\b",
+    r"\bwebrip\b",
+    r"\bbluray\b",
+    r"\bbrrip\b",
+    r"\bh[ .-]?264\b",
+    r"\bh[ .-]?265\b",
+    r"\bx264\b",
+    r"\bx265\b",
+    r"\bac3\b",
+    r"\byify\b",
+    r"\betrg\b",
+    r"\byts\b",
+    r"\bproper\b",
+    r"\bdual audio\b",
+    r"\bmadsky\b",
+]
+
+GARBAGE_REGEXES = [re.compile(pat, re.IGNORECASE) for pat in GARBAGE_PATTERNS]
+NON_ALPHA_NUMERIC_NOISE = re.compile(r"[^A-Za-z0-9\s:/&+().,\-]+")
+
+
+@dataclass(frozen=True)
+class RankedArticle:
+    title: str
+    source: str
+    url: str
+    published_at: str
+    relevance_score: int
 
 
 def parse_symbols(symbols_csv: str, max_symbols: int = 25) -> list[str]:
@@ -8,12 +75,191 @@ def parse_symbols(symbols_csv: str, max_symbols: int = 25) -> list[str]:
     return symbols[:max_symbols]
 
 
+def build_symbol_query(symbol: str) -> str:
+    finance_clause = " OR ".join(
+        [
+            "stock",
+            "shares",
+            "earnings",
+            "revenue",
+            "analyst",
+            "market",
+            "business",
+            "investor",
+            "forecast",
+            "guidance",
+        ]
+    )
+    return f'("{symbol}") AND ({finance_clause})'
+
+
 def fetch_articles_for_symbols(
     client: NewsApiClient,
     symbols: list[str],
     per_symbol_limit: int,
+    minimum_score: int = 3,
 ) -> list[NewsApiArticle]:
-    all_articles: list[NewsApiArticle] = []
-    for sym in symbols:
-        all_articles.extend(client.fetch_recent(sym, per_symbol_limit))
-    return all_articles
+    ranked: list[RankedArticle] = []
+
+    for symbol in symbols:
+        query = build_symbol_query(symbol)
+        raw_articles = client.fetch_recent(query, per_symbol_limit)
+
+        for article in raw_articles:
+            if not is_valid_article_shape(article):
+                continue
+            if is_obviously_garbage(article.title):
+                continue
+
+            score = score_article(article, symbol)
+            if score < minimum_score:
+                continue
+
+            ranked.append(
+                RankedArticle(
+                    title=clean_text(article.title),
+                    source=clean_text(article.source),
+                    url=article.url.strip(),
+                    published_at=article.published_at.strip(),
+                    relevance_score=score,
+                )
+            )
+
+    deduped = dedupe_articles(ranked)
+    deduped.sort(
+        key=lambda a: (a.relevance_score, parse_published_at(a.published_at)), reverse=True
+    )
+
+    return [
+        NewsApiArticle(
+            title=a.title,
+            source=a.source,
+            url=a.url,
+            published_at=a.published_at,
+        )
+        for a in deduped
+    ]
+
+
+def is_valid_article_shape(article: NewsApiArticle) -> bool:
+    if not article.title.strip():
+        return False
+    if not article.url.strip():
+        return False
+
+    parsed = urlparse(article.url)
+    if parsed.scheme not in {"http", "https"}:
+        return False
+
+    return True
+
+
+def is_obviously_garbage(title: str) -> bool:
+    normalized = clean_text(title).lower()
+
+    for regex in GARBAGE_REGEXES:
+        if regex.search(normalized):
+            return True
+
+    if normalized.count("-") >= 4 and any(ch.isdigit() for ch in normalized):
+        return True
+
+    if len(normalized.split()) <= 3:
+        return True
+
+    return False
+
+
+def score_article(article: NewsApiArticle, symbol: str) -> int:
+    title = clean_text(article.title).lower()
+    source = clean_text(article.source).lower()
+
+    score = 0
+
+    if symbol.lower() in title:
+        score += 3
+
+    finance_hits = sum(1 for term in FINANCE_TERMS if term in title)
+    score += min(finance_hits, 4)
+
+    if source in TRUSTED_SOURCES:
+        score += 2
+
+    if is_recent(article.published_at):
+        score += 1
+
+    if any(regex.search(title) for regex in GARBAGE_REGEXES):
+        score -= 10
+
+    if looks_like_release_scene_title(title):
+        score -= 10
+
+    return score
+
+
+TRUSTED_SOURCES = {
+    "reuters",
+    "bloomberg",
+    "cnbc",
+    "marketwatch",
+    "yahoo finance",
+    "benzinga",
+    "the motley fool",
+    "investing.com",
+    "barron's",
+    "fortune",
+    "the wall street journal",
+    "seeking alpha",
+}
+
+
+def looks_like_release_scene_title(title: str) -> bool:
+    upperish_tokens = [t for t in re.split(r"\s+", title) if t]
+    if not upperish_tokens:
+        return False
+
+    noisy_tokens = 0
+    for token in upperish_tokens:
+        if any(ch.isdigit() for ch in token):
+            noisy_tokens += 1
+        if token.isupper() and len(token) >= 4:
+            noisy_tokens += 1
+
+    return noisy_tokens >= 4
+
+
+def dedupe_articles(articles: list[RankedArticle]) -> list[RankedArticle]:
+    best_by_key: dict[str, RankedArticle] = {}
+
+    for article in articles:
+        key = canonical_dedupe_key(article)
+        existing = best_by_key.get(key)
+        if existing is None or article.relevance_score > existing.relevance_score:
+            best_by_key[key] = article
+
+    return list(best_by_key.values())
+
+
+def canonical_dedupe_key(article: RankedArticle) -> str:
+    parsed = urlparse(article.url.strip())
+    path = parsed.path.rstrip("/")
+    host = parsed.netloc.lower()
+    title = re.sub(r"\s+", " ", article.title.strip().lower())
+    return f"{host}{path}|{title}"
+
+
+def parse_published_at(value: str) -> datetime:
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+
+def is_recent(published_at: str, recent_days: int = 7) -> bool:
+    dt = parse_published_at(published_at)
+    return (datetime.now(timezone.utc) - dt).days <= recent_days
+
+
+def clean_text(value: str) -> str:
+    cleaned = NON_ALPHA_NUMERIC_NOISE.sub(" ", value or "")
+    return re.sub(r"\s+", " ", cleaned).strip()

--- a/services/news/tests/test_news.py
+++ b/services/news/tests/test_news.py
@@ -8,17 +8,42 @@ class FakeNewsApiClient:
     def __init__(self):
         self.calls = []
 
-    def fetch_recent(self, symbol: str, limit: int):
-        self.calls.append((symbol, limit))
+    def fetch_recent(self, query: str, limit: int):
+        self.calls.append((query, limit))
+
+        if '"AMZN"' in query:
+            return [
+                type(
+                    "A",
+                    (),
+                    {
+                        "title": "What Makes Amazon (AMZN) an Overall High-Quality Growth Compounder",
+                        "source": "Seeking Alpha",
+                        "url": "https://example.com/amzn-good",
+                        "published_at": "2026-03-01T00:00:00Z",
+                    },
+                )(),
+                type(
+                    "A",
+                    (),
+                    {
+                        "title": "Saipan 2025 1080p AMZN WEB-DL H264-MADSKY",
+                        "source": "Bad Source",
+                        "url": "https://example.com/amzn-bad",
+                        "published_at": "2026-03-01T00:00:00Z",
+                    },
+                )(),
+            ]
+
         return [
             type(
                 "A",
                 (),
                 {
-                    "title": f"{symbol} headline",
-                    "source": "Example",
-                    "url": f"https://example.com/{symbol}",
-                    "published_at": "2026-01-01T00:00:00Z",
+                    "title": "MSFT stock rises after earnings beat expectations",
+                    "source": "Reuters",
+                    "url": "https://example.com/msft-good",
+                    "published_at": "2026-03-01T00:00:00Z",
                 },
             )()
         ]
@@ -27,12 +52,13 @@ class FakeNewsApiClient:
         return None
 
 
-def test_news_dedupes_and_normalizes_symbols():
+def test_news_filters_obvious_garbage_and_normalizes_symbols():
     app = create_app(
         Settings(
             news_api_key="test",
             frontend_origin="http://localhost:5173",
             per_symbol_limit=5,
+            minimum_article_score=3,
             log_level="INFO",
         )
     )
@@ -41,14 +67,18 @@ def test_news_dedupes_and_normalizes_symbols():
     app.dependency_overrides[routes.get_newsapi_client] = lambda: fake
 
     with TestClient(app) as client:
-        resp = client.get("/api/news", params={"symbols": "aapl, AAPL , msft"})
+        resp = client.get("/api/news", params={"symbols": "amzn, AMZN, msft"})
 
     assert resp.status_code == 200
     data = resp.json()
 
-    assert [c[0] for c in fake.calls] == ["AAPL", "MSFT"]
-    assert len(data) == 2
-    assert data[0]["title"] in ("AAPL headline", "MSFT headline")
+    assert len(fake.calls) == 2
+    assert any('"AMZN"' in call[0] for call in fake.calls)
+    assert any('"MSFT"' in call[0] for call in fake.calls)
+
+    titles = [item["title"] for item in data]
+    assert "Saipan 2025 1080p AMZN WEB-DL H264-MADSKY" not in titles
+    assert any("Amazon" in title or "MSFT" in title for title in titles)
 
 
 def test_news_empty_symbols_returns_empty_list():
@@ -57,6 +87,7 @@ def test_news_empty_symbols_returns_empty_list():
             news_api_key="test",
             frontend_origin="http://localhost:5173",
             per_symbol_limit=5,
+            minimum_article_score=3,
             log_level="INFO",
         )
     )

--- a/services/news/tests/test_newsapi_client.py
+++ b/services/news/tests/test_newsapi_client.py
@@ -19,4 +19,36 @@ def test_newsapi_client_non_200_raises():
 
     c = NewsApiClient(api_key="x", http=DummyHttp(), timeout_seconds=0.01)
     with pytest.raises(RuntimeError):
-        c.fetch_recent("AAPL", 5)
+        c.fetch_recent("AAPL stock", 5)
+
+
+def test_newsapi_client_maps_articles():
+    class DummyResp:
+        status_code = 200
+        text = "ok"
+
+        def json(self):
+            return {
+                "articles": [
+                    {
+                        "title": "Amazon stock jumps after earnings",
+                        "source": {"name": "Reuters"},
+                        "url": "https://example.com/article",
+                        "publishedAt": "2026-03-01T00:00:00Z",
+                    }
+                ]
+            }
+
+    class DummyHttp:
+        def get(self, *_args, **_kwargs):
+            return DummyResp()
+
+        def close(self):
+            return None
+
+    c = NewsApiClient(api_key="x", http=DummyHttp(), timeout_seconds=0.01)
+    items = c.fetch_recent("AMZN stock", 5)
+
+    assert len(items) == 1
+    assert items[0].title == "Amazon stock jumps after earnings"
+    assert items[0].source == "Reuters"


### PR DESCRIPTION
## Summary of Changes

This pull request improves the quality and relevance of articles returned by the WealthWise News service.

Previously, the news service queried NewsAPI using only stock ticker symbols and returned all results without validation or filtering. This occasionally allowed unrelated or low-quality content to appear in the news feed when the ticker symbol appeared incidentally within unrelated article titles.

This change introduces a filtering and ranking pipeline within the news service to significantly improve the signal-to-noise ratio of articles shown to users.

### Key Improvements
-   Improved NewsAPI query construction
    -   Queries now include financial context keywords rather than searching only by ticker symbol.
    -   Search scope is limited to article `title` and `description` fields.
    -   Results are sorted by `relevancy` rather than only by publication time.
-   Hard rejection filtering
    -   Articles matching known low-quality patterns (e.g. media release titles like `1080p`, `WEB-DL`, `x264`) are rejected.
    -   Invalid articles lacking a valid title or URL are ignored.
    -   Non‑HTTP URLs are filtered out.
-   Relevance scoring system
    -   Articles are scored using multiple signals including:
        -   ticker presence in title
        -   financial keywords
        -   trusted publisher sources
        -   article recency
    -   Articles below a configurable minimum relevance threshold are discarded.
-   Article deduplication
    -   Duplicate articles are removed using a canonical key derived from URL and normalized title.
    -   When duplicates exist, the highest relevance article is retained.
-   Ranked output
    -   Final articles are sorted by relevance score and then by recency to prioritize meaningful financial news.
-   Expanded automated testing
    -   Unit tests verify symbol normalization and deduplication behavior.
    -   Tests validate filtering logic and upstream client error handling.

------------------------------------------------------------------------

## Related Issue

Closes #16 

------------------------------------------------------------------------

## How Has This Been Tested?

### Manual Testing

The application was executed using the Docker development environment:

    docker compose up --build

Verified:
-   News articles load correctly for portfolios containing common tickers (e.g. AMZN, MSFT).
-   Obvious junk titles containing release-scene patterns are filtered out.
-   Financial news from trusted publishers appears correctly.
-   API responses remain compatible with the existing frontend implementation.

------------------------------------------------------------------------

### Automated Testing

News service tests were executed:

    pytest services/news/tests

Results:
-   All tests passed successfully.
-   Filtering and normalization logic verified through unit tests.
-   Upstream API error handling validated.

------------------------------------------------------------------------

## Architectural Impact

This change improves the robustness of the news service by separating responsibilities between data retrieval and business logic.

The NewsAPI client remains responsible for retrieving raw articles from the upstream provider, while the service layer now applies:
-   normalization
-   hard rejection filtering
-   relevance scoring
-   deduplication
-   ranking

This structure improves maintainability, testability, and content quality while keeping the external API contract unchanged.

------------------------------------------------------------------------

## Checklist

-   [x] Code follows project style guidelines
-   [x] Self-review completed
-   [x] Tests added or updated where appropriate
-   [x] All tests pass
-   [x] No new warnings or runtime errors introduced